### PR TITLE
Link to a copy of Xcode release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ ___
 
 ## Changed in Beta 5
 
+Also see the [official Xcode release notes for Beta 5](http://radex.io/xcode6-release-notes/beta5.pdf).
+
 ### `dynamic` declaration modifier
 
 `dynamic` is a new attribute that can be applied to properties, methods, subscripts and initializers to make all references to them dynamically dispatched (like message passing in Objective-C). This enables KVO, proxying, swizzling and other advanced Cocoa features to work with Swift.
@@ -412,6 +414,8 @@ Source: [Xcode 6 beta 5 release notes](http://radex.io/xcode6-release-notes/beta
 
 ## Changed in Beta 4
 
+Also see the [official Xcode release notes for Beta 4](http://radex.io/xcode6-release-notes/beta4.pdf).
+
 ### Access control
 
 Beta 4 adds three levels of access control to user-defined entities: `public` (available anywhere), `internal` (available within the target where they're defined) and `private` (available only within the file where they're defined).
@@ -529,6 +533,8 @@ Source: https://devforums.apple.com/message/1000950#1000950
 Sources: http://airspeedvelocity.net/2014/07/21/changes-in-the-swift-standard-library-in-beta-4/ [Xcode 6 beta 4 release notes](http://radex.io/xcode6-release-notes/beta4.pdf)
 
 ## Changed in Beta 3
+
+Also see the [official Xcode release notes for Beta 3](http://radex.io/xcode6-release-notes/beta3.pdf).
 
 ### Array and Dictionary type declaration syntax
 Before Beta 3, the shorthand for an Array type was `Type[]`, and Dictionary types were written `Dictionary<KeyType, ValueType>`. Array type shorthand was changed to `[Type]` and Dictionaries types now have a shorthand syntax `[KeyType: ValueType]` (e.g. `[String: Bool]`)


### PR DESCRIPTION
The problem with the links to Xcode release notes is that they use some sort of access protection system — if you try to open one of those PDFs on a computer where you haven't opened it already (through developer.apple.com), it won't work. It will just say "ADC something something expired". Meh.

Another problem is that once a new Beta is out, as far as I can tell, there's no way to access these release notes PDFs from developer.apple.com. If you haven't seen them already or you don't have a direct URL, tough luck.

So I made a copy of all those RN PDFs (preserving history yo) and made the links to RNs point to _those copies_. It should work for everyone now.

Right now, I put them on my own server and I'm committed to make those URL work indefinitely, but obviously it would be best to have them someplace "owned" by SwiftInFlux. I tried putting them on GitHub repo and linking to those, but sadly that triggers downloading of the PDFs instead of just viewing them. Sigh.
