### PR TITLE
Update and rename “Absence of math.h macros”  section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Swift InFlux was created by [Karol S. Mazur](https://github.com/ksm) during [Swi
 
 ### Table of Contents
 
-* [Absence of math.h macros](#absence-of-mathh-macros)
 * [Abstract methods](#abstract-methods)
 * [Access control](#limitations-of-current-access-control-design)
 * [ABI stability](#abi-stability)
@@ -24,6 +23,7 @@ Swift InFlux was created by [Karol S. Mazur](https://github.com/ksm) during [Swi
 * [Enumerating enum types](#enumerating-enum-types)
 * [Flow-sensitive optional unwrapping](#flow-sensitive-optional-unwrapping)
 * [Generic subscripts](#generic-subscripts)
+* [Imported constant macros carry explicit type](#imported-constant-macros-carry-explicit-type)
 * [Moving functionality from global functions to methods](#moving-functionality-from-global-functions-to-methods)
 * [Open source possibility](#open-source-possibility)
 * [Optionals in imported Objective-C frameworks](#optionals-in-imported-objective-c-frameworks)
@@ -112,16 +112,6 @@ ___
   * [Range operators](#range-operators)
 
 ---
-
-### Absence of math.h macros
-
-> FWIW, we consider it to be a bug that M_PI (and a variety of other imported constants) get an arbitrary fixed type assigned to them.  This affects integer constants just as much as floating point ones.
->
-> In principle, there could be a way to provide "typeless named literals" in the language, and constants imported from C macros could be imported like that.  I don't know if that's the approach we'll take, but it is one of several different options we'll evaluate down the road to improve this situation.
->
-> — Chris Lattner
-
-Source: https://devforums.apple.com/message/1032523#1032523
 
 ### Abstract methods
 
@@ -259,6 +249,21 @@ Source: https://devforums.apple.com/message/1005148#1005148 https://devforums.ap
 Currently, generic subscripts are allowed only for generic types (e.g. `Array`, `Dictionary`).
 
 Source: https://devforums.apple.com/message/1100335#1100335
+
+### Imported constant macros carry explicit type
+
+Since Swift does not allow implicit type conversion, imported constant C and
+Objective-C macros lose a bit of flexibility in use as they carry an explicit
+type (Swift has no preprocessor). For example, `M_PI` from `math.h` is imported
+as a double.
+
+> FWIW, we consider it to be a bug that M_PI (and a variety of other imported constants) get an arbitrary fixed type assigned to them.  This affects integer constants just as much as floating point ones.
+>
+> In principle, there could be a way to provide "typeless named literals" in the language, and constants imported from C macros could be imported like that.  I don't know if that's the approach we'll take, but it is one of several different options we'll evaluate down the road to improve this situation.
+>
+> — Chris Lattner
+
+Source: https://devforums.apple.com/message/1032523#1032523
 
 ### Moving functionality from global functions to methods
 

--- a/README.md
+++ b/README.md
@@ -115,17 +115,13 @@ ___
 
 ### Absence of math.h macros
 
-> This is a known problem, it will be fixed in later betas.
->
-> — Chris Lattner
->
 > FWIW, we consider it to be a bug that M_PI (and a variety of other imported constants) get an arbitrary fixed type assigned to them.  This affects integer constants just as much as floating point ones.
 >
 > In principle, there could be a way to provide "typeless named literals" in the language, and constants imported from C macros could be imported like that.  I don't know if that's the approach we'll take, but it is one of several different options we'll evaluate down the road to improve this situation.
 >
 > — Chris Lattner
 
-Source: https://devforums.apple.com/message/989902#989902 https://devforums.apple.com/message/1032523#1032523
+Source: https://devforums.apple.com/message/1032523#1032523
 
 ### Abstract methods
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Swift InFlux was created by [Karol S. Mazur](https://github.com/ksm) during [Swi
 * [C++ support](#c-support)
 * [Dynamic dispatch of operators](#dynamic-dispatch-of-operators)
 * [Enumerating enum types](#enumerating-enum-types)
-* [Generic subscripts](#generic-subscripts)
 * [Flow-sensitive optional unwrapping](#flow-sensitive-optional-unwrapping)
+* [Generic subscripts](#generic-subscripts)
 * [Moving functionality from global functions to methods](#moving-functionality-from-global-functions-to-methods)
 * [Open source possibility](#open-source-possibility)
 * [Optionals in imported Objective-C frameworks](#optionals-in-imported-objective-c-frameworks)
@@ -228,16 +228,6 @@ Source: https://devforums.apple.com/message/1074064#1074064
 
 Source: https://devforums.apple.com/message/1003674#1003674
 
-### Generic subscripts
-
-> Lack of generic subscripts is a known limitation.  We'll look at improving this at some point when it bubbles up in the priority list.
-> 
-> — Chris Lattner
-
-Currently, generic subscripts are allowed only for generic types (e.g. `Array`, `Dictionary`).
-
-Source: https://devforums.apple.com/message/1100335#1100335
-
 ### Flow-sensitive optional unwrapping
 
 It has been suggested that optional types could be implicitly unwrapped in the context of an if-statement checking if an optional has a value, for example:
@@ -259,6 +249,16 @@ if exists x {
 > — CFM
 
 Source: https://devforums.apple.com/message/1005148#1005148 https://devforums.apple.com/message/1066436#1066436
+
+### Generic subscripts
+
+> Lack of generic subscripts is a known limitation.  We'll look at improving this at some point when it bubbles up in the priority list.
+>
+> — Chris Lattner
+
+Currently, generic subscripts are allowed only for generic types (e.g. `Array`, `Dictionary`).
+
+Source: https://devforums.apple.com/message/1100335#1100335
 
 ### Moving functionality from global functions to methods
 


### PR DESCRIPTION
The first quote of the section is about the absence of `math.h` macros, which was from June of last year, and has been fixed, and seems for a while now too as the second quote is about an issue using `M_PI` from `math.h` (carrying type, see below), which was from August. So I removed the quote and source from that section.

This is legal Swift code

```swift
// Darwin, Foundation, etc. all work too
import Cocoa

// Various math.h macros and functions
M_PI
signbit(1.0)
M_E
log10(2.0)
```

The second quote is about another issue, not related to `math.h` in particular, but rather with importing constant C and Objective-C macros in general. So I renamed the section accordingly.

Finally, made a section alpha ordering fix.

_**P.S.**_ Realized I forgot to mention this before - thanks for the great project! :)