### PR TITLE
Obsoletion notice and link to Swift Evolution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## This document is no longer maintained.
+
+
+With Swift [becoming open-source](https://swift.org) - and the [Swift Evolution] (https://github.com/apple/swift-evolution) document being public, this project was made mostly obsolete. However, it still serves as a historical account of Swift's initial evolution.
+
+========
+
 Swift InFlux
 ===========
 The community is creating some incredible analyses and writing about Swift. What I keep asking myself whenever learning and reading about Swift is: how likely is this to change soon?


### PR DESCRIPTION
I think the sad fact was that none of the maintainers (guilty as charged) was interested in actively maintaining this thing anymore. It was nice while it lasted etc etc etc

Let's officially put it out of the misery and link to the official Swift Evolution doc :)

Unless someone from the broader community is interested in back porting all the Xcode 7 changes and maintaining this going forward?

@ksm @radex - I think both of you should give a-ok for doing this?
